### PR TITLE
(Feature) Delegate Api

### DIFF
--- a/config/param-validation.js
+++ b/config/param-validation.js
@@ -73,17 +73,26 @@ module.exports = {
     }
   },
 
-  // GET /api/delegate/:address
+  // GET /api/delegates/:address
   getDelegate: {
     params: {
       address: Joi.string().required()
     }
   },
 
-  // GET /api/delegate/roi/:address
+  // GET /api/delegates/roi/:address
   getDelegateRoi: {
     params: {
       address: Joi.string().required()
+    }
+  },
+
+  // GET /api/delegates/top/:number
+  getTopDelegates: {
+    params: {
+      number: Joi.number()
+        .min(0)
+        .required()
     }
   }
 }

--- a/config/param-validation.js
+++ b/config/param-validation.js
@@ -78,21 +78,5 @@ module.exports = {
     params: {
       address: Joi.string().required()
     }
-  },
-
-  // GET /api/delegates/roi/:address
-  getDelegateRoi: {
-    params: {
-      address: Joi.string().required()
-    }
-  },
-
-  // GET /api/delegates/top/:number
-  getTopDelegates: {
-    params: {
-      number: Joi.number()
-        .min(0)
-        .required()
-    }
   }
 }

--- a/config/param-validation.js
+++ b/config/param-validation.js
@@ -75,7 +75,7 @@ module.exports = {
   },
 
   // GET /api/delegate/roi/:address
-  getDelegateRoi: {
+  getDelegateROI: {
     params: {
       address: Joi.string().required()
     }

--- a/index.route.js
+++ b/index.route.js
@@ -17,6 +17,6 @@ router.use('/telegrams', telegramRouters)
 
 router.use('/rounds', roundRouters)
 
-router.use('/delegate', delegateRouters)
+router.use('/delegates', delegateRouters)
 
 module.exports = router

--- a/server/delegate/delegate.controller.js
+++ b/server/delegate/delegate.controller.js
@@ -3,7 +3,7 @@
  * @returns {Subscriber}
  */
 
-const utils = require('../helpers/utils')
+const { MathBN, tokenAmountInUnits } = require('../helpers/utils')
 const BN = require('bn.js')
 const {
   getDelegate,
@@ -20,7 +20,7 @@ const getByAddress = async (req, res, next) => {
     next(error)
   }
 }
-const delegateRoi = async (req, res, next) => {
+const getROI = async (req, res, next) => {
   const { address } = req.params
   try {
     const rewards = await getDelegateRewards(address)
@@ -30,10 +30,10 @@ const delegateRoi = async (req, res, next) => {
       const totalReward = rewards.reduce((total, reward) => {
         // Removes the cases in which the rewardToken is null
         const rewardTokenAmount = reward.rewardTokens ? reward.rewardTokens : 0
-        const amount = utils.tokenAmountInUnits(rewardTokenAmount)
-        return utils.MathBN.add(total, amount)
+        const amount = tokenAmountInUnits(rewardTokenAmount)
+        return MathBN.add(total, amount)
       }, new BN(0))
-      result = utils.MathBN.div(totalReward, totalStake)
+      result = MathBN.div(totalReward, totalStake)
     }
 
     res.json(result)
@@ -44,5 +44,5 @@ const delegateRoi = async (req, res, next) => {
 
 module.exports = {
   getByAddress,
-  delegateRoi
+  getROI
 }

--- a/server/delegate/delegate.controller.js
+++ b/server/delegate/delegate.controller.js
@@ -3,7 +3,7 @@
  * @returns {Subscriber}
  */
 
-const { getDelegate, getDelegateRoi } = require('../helpers/graphql/delegate')
+const { getDelegate } = require('../helpers/graphql/delegate')
 
 const delegateByAddress = async (req, res, next) => {
   const { address = null } = req.params
@@ -16,18 +16,6 @@ const delegateByAddress = async (req, res, next) => {
   }
 }
 
-const delegateRoi = async (req, res, next) => {
-  const { address = null } = req.params
-  let result = null
-  try {
-    result = await getDelegateRoi(address)
-    res.json(result)
-  } catch (error) {
-    next(error)
-  }
-}
-
 module.exports = {
-  delegateByAddress,
-  delegateRoi
+  delegateByAddress
 }

--- a/server/delegate/delegate.controller.js
+++ b/server/delegate/delegate.controller.js
@@ -3,31 +3,24 @@
  * @returns {Subscriber}
  */
 
-const utils = require('../helpers/utils')
-const graphqlDelegate = require('../helpers/graphql/delegate')
-const BN = require('bn.js')
+const { getDelegate, getDelegateRoi } = require('../helpers/graphql/delegate')
 
 const delegateByAddress = async (req, res, next) => {
   const { address = null } = req.params
+  let result = null
+  try {
+    result = await getDelegate(address)
+    res.json(result)
+  } catch (error) {
+    next(error)
+  }
 }
 
 const delegateRoi = async (req, res, next) => {
   const { address = null } = req.params
   let result = null
   try {
-    const rewards = await graphqlDelegate.getTranscoderRewards(address)
-    const totalStake = await graphqlDelegate.getTranscoderTotalStake(address)
-
-    if (rewards && totalStake) {
-      const totalReward = rewards.reduce((total, reward) => {
-        // Removes the cases in which the rewardToken is null
-        const rewardTokenAmount = reward.rewardTokens ? reward.rewardTokens : 0
-        const amount = utils.tokenAmountInUnits(rewardTokenAmount)
-        return utils.MathBN.add(total, amount)
-      }, new BN(0))
-      result = utils.MathBN.div(totalReward, totalStake)
-    }
-
+    result = await getDelegateRoi(address)
     res.json(result)
   } catch (error) {
     next(error)

--- a/server/delegate/delegate.controller.js
+++ b/server/delegate/delegate.controller.js
@@ -5,7 +5,11 @@
 
 const utils = require('../helpers/utils')
 const BN = require('bn.js')
-const { getDelegate, getDelegateRewards, getDelegateTotalStake } = require('../helpers/graphql/queries/delegate')
+const {
+  getDelegate,
+  getDelegateRewards,
+  getDelegateTotalStake
+} = require('../helpers/graphql/queries/delegate')
 
 const getByAddress = async (req, res, next) => {
   const { address } = req.params

--- a/server/delegate/delegate.controller.js
+++ b/server/delegate/delegate.controller.js
@@ -25,7 +25,7 @@ const getROI = async (req, res, next) => {
   try {
     const rewards = await getDelegateRewards(address)
     const totalStake = await getDelegateTotalStake(address)
-    let result = null
+    let roi = null
     if (rewards && totalStake) {
       const totalReward = rewards.reduce((total, reward) => {
         // Removes the cases in which the rewardToken is null
@@ -33,10 +33,10 @@ const getROI = async (req, res, next) => {
         const amount = tokenAmountInUnits(rewardTokenAmount)
         return MathBN.add(total, amount)
       }, new BN(0))
-      result = MathBN.div(totalReward, totalStake)
+      roi = MathBN.div(totalReward, totalStake)
     }
 
-    res.json(result)
+    res.json({ roi })
   } catch (error) {
     next(error)
   }

--- a/server/delegate/delegate.route.js
+++ b/server/delegate/delegate.route.js
@@ -3,18 +3,12 @@ const validate = require('express-validation')
 const paramValidation = require('../../config/param-validation')
 
 const router = express.Router() // eslint-disable-line new-cap
-const { delegateByAddress, delegateRoi } = require('./delegate.controller')
+const { delegateByAddress } = require('./delegate.controller')
 
-/** GET /api/delegate/:address - Get delegate by address */
+/** GET /api/delegates/:address - Get delegate by address */
 router
   .route('/:address')
 
   .get(validate(paramValidation.getDelegate), delegateByAddress)
-
-/** GET /api/delegate/roi/:address - Get delegate ROI by address */
-router
-  .route('/roi/:address')
-
-  .get(validate(paramValidation.getDelegateRoi), delegateRoi)
 
 module.exports = router

--- a/server/delegate/delegate.route.js
+++ b/server/delegate/delegate.route.js
@@ -7,7 +7,7 @@ const { getByAddress, getROI } = require('./delegate.controller')
 
 /** GET /api/delegate/address/:address - Get delegate by address */
 router
-  .route('/address/:address')
+  .route('/:address')
 
   .get(validate(paramValidation.getByAddress), getByAddress)
 

--- a/server/delegate/delegate.route.js
+++ b/server/delegate/delegate.route.js
@@ -3,7 +3,7 @@ const validate = require('express-validation')
 const paramValidation = require('../../config/param-validation')
 
 const router = express.Router() // eslint-disable-line new-cap
-const { getByAddress, delegateRoi } = require('./delegate.controller')
+const { getByAddress, getROI } = require('./delegate.controller')
 
 /** GET /api/delegate/address/:address - Get delegate by address */
 router
@@ -15,6 +15,6 @@ router
 router
   .route('/roi/:address')
 
-  .get(validate(paramValidation.getDelegateRoi), delegateRoi)
+  .get(validate(paramValidation.getDelegateROI), getROI)
 
 module.exports = router

--- a/server/helpers/graphql/delegate.js
+++ b/server/helpers/graphql/delegate.js
@@ -1,12 +1,60 @@
+const { getCurrentRound } = require('./protocol')
+
 const { client } = require('./apolloClient')
 const gql = require('graphql-tag')
+const BN = require('bn.js')
+const { MathBN, tokenAmountInUnits } = require('../utils')
 
-const getTranscoderRewards = async transcoderAddress => {
+// Returns the delegate summary, does not include rewards, ROI, missed reward calls or any calculated data
+const getDelegateSummary = async delegateAddress => {
   const queryResult = await client.query({
     query: gql`
       {
-        rewards(where: { transcoder: "${transcoderAddress}" }) {
+        transcoder(id: "${delegateAddress}") {
+          id,
+          active,
+          ensName,
+          status,
+          lastRewardRound,
+          rewardCut,
+          feeShare,
+          pricePerSegment,
+          pendingRewardCut,
+          pendingFeeShare,
+          pendingPricePerSegment,
+          totalStake
+        }
+      }
+    `
+  })
+  return queryResult.data && queryResult.data.transcoder ? queryResult.data.transcoder : null
+}
+
+// Returns the delegate summary plus the ROI and missed reward calls
+const getDelegate = async delegateAddress => {
+  const summary = await getDelegateSummary(delegateAddress)
+  const roi = await getDelegateRoi(delegateAddress)
+  const last30MissedRewardCalls = await getMissedRewardCalls(delegateAddress)
+  return {
+    summary: {
+      ...summary,
+      totalStake: summary.totalStake ? tokenAmountInUnits(summary.totalStake) : null,
+      roi,
+      last30MissedRewardCalls
+    }
+  }
+}
+
+// Returns the amount of tokens rewards on each round for the given delegate
+const getDelegateRewards = async delegateAddress => {
+  const queryResult = await client.query({
+    query: gql`
+      {
+        rewards(where: { transcoder: "${delegateAddress}" }) {
           rewardTokens
+          round {
+            id
+          }
         }
       }
     `
@@ -14,11 +62,11 @@ const getTranscoderRewards = async transcoderAddress => {
   return queryResult.data && queryResult.data.rewards ? queryResult.data.rewards : null
 }
 
-const getTranscoderTotalStake = async transcoderAddress => {
+const getDelegateTotalStake = async delegateAddress => {
   const queryResult = await client.query({
     query: gql`
       {
-        transcoder(id: "${transcoderAddress}") {
+        transcoder(id: "${delegateAddress}") {
           totalStake
         }
       }
@@ -29,7 +77,44 @@ const getTranscoderTotalStake = async transcoderAddress => {
     : null
 }
 
+const getDelegateRoi = async delegateAddress => {
+  const rewards = await getDelegateRewards(delegateAddress)
+  const totalStake = await getDelegateTotalStake(delegateAddress)
+  if (!rewards && !totalStake) {
+    return null
+  } else {
+    const totalReward = rewards.reduce((total, reward) => {
+      // Removes the cases in which the rewardToken is null
+      const rewardTokenAmount = reward.rewardTokens ? reward.rewardTokens : 0
+      const amount = tokenAmountInUnits(rewardTokenAmount)
+      return MathBN.add(total, amount)
+    }, new BN(0))
+    return MathBN.div(totalReward, totalStake)
+  }
+}
+
+const getMissedRewardCalls = async delegateAddress => {
+  let missedCalls = 0
+  const rewards = await getDelegateRewards(delegateAddress)
+  const currentRound = await getCurrentRound()
+
+  if (rewards) {
+    missedCalls = rewards
+      .sort((a, b) => b.round.id - a.round.id)
+      .filter(
+        reward =>
+          reward.rewardTokens === null &&
+          reward.round.id >= currentRound.id - 30 &&
+          reward.round.id !== currentRound.id
+      ).length
+  }
+  return missedCalls
+}
+
 module.exports = {
-  getTranscoderRewards,
-  getTranscoderTotalStake
+  getDelegate,
+  getDelegateRewards,
+  getDelegateTotalStake,
+  getDelegateRoi,
+  getMissedRewardCalls
 }

--- a/server/helpers/graphql/protocol.js
+++ b/server/helpers/graphql/protocol.js
@@ -1,0 +1,21 @@
+const { client } = require('./apolloClient')
+const gql = require('graphql-tag')
+
+const CurrentRoundQuery = gql`
+  {
+    rounds(first: 1) {
+      id
+    }
+  }
+`
+
+const getCurrentRound = async () => {
+  const queryResult = await client.query({
+    query: CurrentRoundQuery
+  })
+  return queryResult.data && queryResult.data.rounds ? queryResult.data.rounds[0] : null
+}
+
+module.exports = {
+  getCurrentRound
+}

--- a/server/helpers/test/util.js
+++ b/server/helpers/test/util.js
@@ -1,0 +1,37 @@
+const createRewardObject = (transcoderId, roundId) => {
+  // ID between 1 and 100
+  const id = Math.floor(Math.random() * 100 + 1)
+  // Reward token between 1*10.pow(21) and 99 * 10.pow(21)
+  const base = Math.pow(10, 21)
+  const top = 9 * Math.pow(10, 21)
+  const rewardTokens = Math.floor(Math.random() * top + base).toString()
+  const transcoder = createTranscoder(transcoderId)
+  const round = createRoundObject(roundId)
+  return {
+    id,
+    rewardTokens,
+    transcoder,
+    round
+  }
+}
+
+const createRoundObject = roundId => {
+  return {
+    id: roundId
+  }
+}
+
+// TODO Complete with all the fields
+const createTranscoder = transcoderId => {
+  return {
+    id: transcoderId,
+    active: true,
+    status: 'Registered'
+  }
+}
+
+module.exports = {
+  createRewardObject,
+  createRoundObject,
+  createTranscoder
+}

--- a/server/helpers/utils.js
+++ b/server/helpers/utils.js
@@ -293,6 +293,20 @@ const tokenAmountInUnits = (amount, decimals = 18) => {
   return MathBN.div(amountAsBN, decimalsPerToken)
 }
 
+const calculateMissedRewardCalls = (rewards, currentRound) => {
+  if (!currentRound || !rewards) {
+    return 0
+  }
+  return rewards
+    .sort((a, b) => b.round.id - a.round.id)
+    .filter(
+      reward =>
+        reward.rewardTokens === null &&
+        reward.round.id >= currentRound.id - 30 &&
+        reward.round.id !== currentRound.id
+    ).length
+}
+
 module.exports = {
   MathBN,
   truncateStringInTheMiddle,
@@ -311,5 +325,6 @@ module.exports = {
   getEarningParams,
   getSubscriptorRole,
   getDelegatorRoundsUntilUnbonded,
-  tokenAmountInUnits
+  tokenAmountInUnits,
+  calculateMissedRewardCalls
 }

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -1,0 +1,74 @@
+const { createRewardObject } = require('../server/helpers/test/util')
+const BN = require('bn.js')
+const { calculateMissedRewardCalls } = require('../server/helpers/utils')
+const chai = require('chai') // eslint-disable-line import/newline-after-import
+const expect = chai.expect
+const assert = chai.assert
+const { MathBN } = require('../server/helpers/utils')
+
+chai.config.includeStack = true
+
+describe('## Utils file test', () => {
+  describe('# Missed reward call calculation', () => {
+    it('There are 30 rounds, 10 of them do not have reward object, result should be 10', done => {
+      // given
+      const rewards = []
+      const transcoderId = '1'
+      const currentRound = {
+        id: 30
+      }
+      for (let roundI = 1; roundI <= 30; roundI++) {
+        const newReward = createRewardObject(transcoderId, roundI)
+        if (roundI <= 10) {
+          newReward.rewardTokens = null
+        }
+        rewards.push(newReward)
+      }
+      // when
+      const missedRewardCalls = calculateMissedRewardCalls(rewards, currentRound)
+      // then
+      expect(missedRewardCalls).to.equal(10)
+      done()
+    })
+    it('There are 40 rounds, the firsts 5 of them do not have reward object, neither the last 10 of them, result should be 5', done => {
+      // given
+      const rewards = []
+      const transcoderId = '1'
+      const currentRound = {
+        id: 40
+      }
+      for (let roundI = 1; roundI <= 40; roundI++) {
+        const newReward = createRewardObject(transcoderId, roundI)
+        if (roundI <= 5) {
+          newReward.rewardTokens = null
+        }
+        if (roundI >= 35) {
+          newReward.rewardTokens = null
+        }
+        rewards.push(newReward)
+      }
+      // when
+      const missedRewardCalls = calculateMissedRewardCalls(rewards, currentRound)
+      // then
+      expect(missedRewardCalls).to.equal(5)
+      done()
+    })
+    it('There are 30 rounds, all of them have reward, result should be 0', done => {
+      // given
+      const rewards = []
+      const transcoderId = '1'
+      const currentRound = {
+        id: 30
+      }
+      for (let roundI = 1; roundI <= 30; roundI++) {
+        const newReward = createRewardObject(transcoderId, roundI)
+        rewards.push(newReward)
+      }
+      // when
+      const missedRewardCalls = calculateMissedRewardCalls(rewards, currentRound)
+      // then
+      expect(missedRewardCalls).to.equal(0)
+      done()
+    })
+  })
+})

--- a/utils/livepeer-alerts-backend.postman_collection.json
+++ b/utils/livepeer-alerts-backend.postman_collection.json
@@ -424,7 +424,7 @@
 			"response": []
 		},
 		{
-			"name": "[DELETE] - /api/delegate/address/:address",
+			"name": "[GET] - /api/delegates/:address",
 			"protocolProfileBehavior": {
 				"disableBodyPruning": true
 			},
@@ -448,14 +448,52 @@
 					"raw": "{\n\t\"username\": \"Fernando\"\n}"
 				},
 				"url": {
-					"raw": "{{host}}/api/delegate/address/0x50d69f8253685999b4c74a67ccb3d240e2a56ed6",
+					"raw": "{{host}}/api/delegates/0x50d69f8253685999b4c74a67ccb3d240e2a56ed6",
 					"host": [
 						"{{host}}"
 					],
 					"path": [
 						"api",
-						"delegate",
-						"address",
+						"delegates",
+						"0x50d69f8253685999b4c74a67ccb3d240e2a56ed6"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "[GET] - /api/delegates/roi/:address",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"type": "text",
+						"value": "application/json"
+					},
+					{
+						"key": "Referer",
+						"type": "text",
+						"value": "http://localhost:3000"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"username\": \"Fernando\"\n}"
+				},
+				"url": {
+					"raw": "{{host}}/api/delegates/roi/0x50d69f8253685999b4c74a67ccb3d240e2a56ed6",
+					"host": [
+						"{{host}}"
+					],
+					"path": [
+						"api",
+						"delegates",
+						"roi",
 						"0x50d69f8253685999b4c74a67ccb3d240e2a56ed6"
 					]
 				}


### PR DESCRIPTION
Depends on #37 

### Description
Let the user receive information about a delegate by address. Uses GRAPHQL

The information that could be fetched is:

- DelegateSummary: returns the delegator summary using grapqhl, also returns the `last30MissedRewardCalls` and the roi of the given delegate

Examples:
```
Given: http://localhost:4040/api/delegates/0x4f4758f7167b18e1f5b3c1a7575e3eb584894dbc

Result:
{
    "summary": {
        "id": "0x4f4758f7167b18e1f5b3c1a7575e3eb584894dbc",
        "active": true,
        "ensName": null,
        "status": "Registered",
        "lastRewardRound": "0",
        "rewardCut": "0",
        "feeShare": "0",
        "pricePerSegment": "0",
        "pendingRewardCut": "500000",
        "pendingFeeShare": "0",
        "pendingPricePerSegment": "171000000000",
        "totalStake": "179855.334193555900061178",
        "__typename": "Transcoder",
        "last30MissedRewardCalls": 0
    }
}
```
