### PR TITLE
(Feature) Refactors delegate called reward calculation on telegram jobs 

### DIFF
--- a/server/helpers/sendTelegramClaimRewardCall.js
+++ b/server/helpers/sendTelegramClaimRewardCall.js
@@ -19,7 +19,8 @@ const {
   getButtonsBySubscriptor,
   truncateStringInTheMiddle,
   formatBalance,
-  getDelegatorRoundsUntilUnbonded
+  getDelegatorRoundsUntilUnbonded,
+  getDidDelegateCallReward
 } = require('./utils')
 
 const sendTelegramClaimRewardCall = async data => {
@@ -63,15 +64,12 @@ const getTelegramClaimRewardCallBody = async subscriber => {
   switch (delegator.status) {
     case constants.DELEGATOR_STATUS.Bonded:
       // Check call reward
-      let [transcoderAccount, currentRound] = await promiseRetry(async retry => {
-        return Promise.all([
-          getLivepeerTranscoderAccount(delegator.delegateAddress),
-          protocolService.getCurrentRound()
-        ]).catch(err => retry())
+      let [currentRound] = await promiseRetry(async retry => {
+        return Promise.all([protocolService.getCurrentRound()]).catch(err => retry())
       })
 
       // Check if call reward
-      const callReward = transcoderAccount && transcoderAccount.lastRewardRound === currentRound
+      const callReward = await getDidDelegateCallReward(delegator.delegateAddress)
       // Open template file
       const filenameBonded = callReward
         ? '../notifications/telegram/delegate-claim-reward-call/notification-success.hbs'
@@ -89,7 +87,7 @@ const getTelegramClaimRewardCallBody = async subscriber => {
         .startOf('day')
         .format('dddd DD, YYYY hh:mm A')
 
-      const { delegateAddress, totalStake } = delegator
+      const { delegateAddress } = delegator
 
       // Create telegram generator
       const templateBonded = Handlebars.compile(sourceBonded)


### PR DESCRIPTION
No issue related
Refactors both `sendTelegramClaimRewardCall()` and `getBodyBySubscriber()` functions in order to use the `getDidDelegateCallReward()` utility function
