### PR TITLE
(Hotfix) Top delegates calculation

### DIFF
--- a/server/delegate/delegate.controller.js
+++ b/server/delegate/delegate.controller.js
@@ -9,7 +9,7 @@ const getByAddress = async (req, res, next) => {
   const { address } = req.params
   const delegateService = getDelegateService()
   try {
-    const result = await delegateService.getDelegate(address)
+    const result = await delegateService.getDelegateSummary(address)
     res.json(result)
   } catch (error) {
     next(error)

--- a/test/delegate.test.js
+++ b/test/delegate.test.js
@@ -40,10 +40,31 @@ describe('## DelegateService test', () => {
 
       // then
       expect(getSummaryStub.called)
-      expect(result.summary).to.deep.equal(resultExpected)
+      expect(result).to.deep.equal(resultExpected)
       // restore stubs
       getSummaryStub.restore()
     })
+  })
+  it('getDelegateSummary should return a delegate summary', async () => {
+    // given
+    const delegate = createTranscoder()
+    // stubs the delegateGraphql service
+    const getSummaryStub = sinon.stub(delegatesGraphql, 'getDelegateSummary').returns(delegate)
+    const resultExpected = {
+      summary: {
+        ...delegate,
+        totalStake: tokenAmountInUnits(delegate.totalStake)
+      }
+    }
+
+    // when
+    const result = await delegateService.getDelegateSummary()
+
+    // then
+    expect(getSummaryStub.called)
+    expect(result).to.deep.equal(resultExpected)
+    // restore stubs
+    getSummaryStub.restore()
   })
   describe('# getDelegateProtocolNextReward', () => {
     // bondedStake = 400


### PR DESCRIPTION
No issue related

The values of the ROI in top delegates where all the same, the problemas was the usage of getDelegate() function. it was expected to return directly the reward cut, but was a summary object instead