### PR TITLE
(Hotfix) Delegate summary

### DIFF
--- a/server/helpers/graphql/queries/delegate.js
+++ b/server/helpers/graphql/queries/delegate.js
@@ -4,7 +4,7 @@ const gql = require('graphql-tag')
 const _ = require('lodash')
 
 // Returns the delegate summary, does not include rewards, ROI, missed reward calls or any calculated data
-const getDelegateSummary = async delegateAddress => {
+const getLivepeerTranscoderAccount = async delegateAddress => {
   const queryResult = await client.query({
     query: gql`
       {
@@ -108,7 +108,7 @@ const getLivepeerTranscoders = async () => {
 }
 
 module.exports = {
-  getDelegateSummary,
+  getLivepeerTranscoderAccount,
   getRegisteredDelegates,
   getDelegateRewards,
   getDelegateTotalStake,

--- a/server/helpers/graphql/queries/delegate.js
+++ b/server/helpers/graphql/queries/delegate.js
@@ -4,7 +4,7 @@ const gql = require('graphql-tag')
 const _ = require('lodash')
 
 // Returns the delegate summary, does not include rewards, ROI, missed reward calls or any calculated data
-const getLivepeerTranscoderAccount = async delegateAddress => {
+const getLivepeerDelegateAccount = async delegateAddress => {
   const queryResult = await client.query({
     query: gql`
       {
@@ -83,7 +83,7 @@ const getDelegateTotalStake = async delegateAddress => {
   return _.get(queryResult, 'data.transcoder.totalStake', null)
 }
 
-const getLivepeerTranscoders = async () => {
+const getLivepeerDelegates = async () => {
   const queryResult = await client.query({
     query: gql`
       {
@@ -108,9 +108,9 @@ const getLivepeerTranscoders = async () => {
 }
 
 module.exports = {
-  getLivepeerTranscoderAccount,
+  getLivepeerDelegateAccount,
   getRegisteredDelegates,
   getDelegateRewards,
   getDelegateTotalStake,
-  getLivepeerTranscoders
+  getLivepeerDelegates
 }

--- a/server/helpers/graphql/queries/index.js
+++ b/server/helpers/graphql/queries/index.js
@@ -1,5 +1,5 @@
 const {
-  getDelegateSummary,
+  getLivepeerTranscoderAccount,
   getDelegateRewards,
   getDelegateTotalStake,
   getRegisteredDelegates,
@@ -8,7 +8,7 @@ const {
 const { getCurrentRound } = require('./protocol')
 
 module.exports = {
-  getDelegateSummary,
+  getLivepeerTranscoderAccount,
   getDelegateRewards,
   getDelegateTotalStake,
   getRegisteredDelegates,

--- a/server/helpers/graphql/queries/index.js
+++ b/server/helpers/graphql/queries/index.js
@@ -1,17 +1,17 @@
 const {
-  getLivepeerTranscoderAccount,
+  getLivepeerDelegateAccount,
   getDelegateRewards,
   getDelegateTotalStake,
   getRegisteredDelegates,
-  getLivepeerTranscoders
+  getLivepeerDelegates
 } = require('./delegate')
 const { getCurrentRound } = require('./protocol')
 
 module.exports = {
-  getLivepeerTranscoderAccount,
+  getLivepeerDelegateAccount,
   getDelegateRewards,
   getDelegateTotalStake,
   getRegisteredDelegates,
   getCurrentRound,
-  getLivepeerTranscoders
+  getLivepeerDelegates
 }

--- a/server/helpers/sdk/delegate.js
+++ b/server/helpers/sdk/delegate.js
@@ -1,11 +1,11 @@
 const LivepeerSDK = require('@livepeer/sdk')
 
-const getLivepeerTranscoders = async () => {
+const getLivepeerDelegates = async () => {
   const { rpc } = await LivepeerSDK.default()
   return await rpc.getTranscoders()
 }
 
-const getLivepeerTranscoderAccount = async address => {
+const getLivepeerDelegateAccount = async address => {
   if (!address) {
     return null
   }
@@ -14,6 +14,6 @@ const getLivepeerTranscoderAccount = async address => {
 }
 
 module.exports = {
-  getLivepeerTranscoders,
-  getLivepeerTranscoderAccount
+  getLivepeerDelegates,
+  getLivepeerDelegateAccount
 }

--- a/server/helpers/sdk/index.js
+++ b/server/helpers/sdk/index.js
@@ -1,4 +1,4 @@
-const { getLivepeerTranscoderAccount, getLivepeerTranscoders } = require('./delegate')
+const { getLivepeerDelegateAccount, getLivepeerDelegates } = require('./delegate')
 const {
   getLivepeerCurrentRound,
   getTotalBonded,
@@ -23,8 +23,8 @@ module.exports = {
   getLivepeerDelegatorAccount,
   getLivepeerDelegatorStake,
   getLivepeerDelegatorTokenBalance,
-  getLivepeerTranscoderAccount,
-  getLivepeerTranscoders,
+  getLivepeerDelegateAccount,
+  getLivepeerDelegates,
   getLivepeerCurrentRound,
   getTotalBonded,
   getInflationChange,

--- a/server/helpers/services/delegateService.js
+++ b/server/helpers/services/delegateService.js
@@ -28,11 +28,13 @@ class DelegateService {
 
   // Returns the delegate summary
   getDelegateSummary = async delegateAddress => {
-    const { getDelegateSummary } = this.source
-    const summary = await getDelegateSummary(delegateAddress)
+    const { getLivepeerTranscoderAccount } = this.source
+    const summary = await getLivepeerTranscoderAccount(delegateAddress)
+    const { address } = summary
     return {
       summary: {
         ...summary,
+        id: address,
         totalStake: tokenAmountInUnits(_.get(summary, 'totalStake', 0))
       }
     }

--- a/server/helpers/services/delegateService.js
+++ b/server/helpers/services/delegateService.js
@@ -28,8 +28,8 @@ class DelegateService {
 
   // Returns the delegate summary
   getDelegateSummary = async delegateAddress => {
-    const { getLivepeerTranscoderAccount } = this.source
-    const summary = await getLivepeerTranscoderAccount(delegateAddress)
+    const { getLivepeerDelegateAccount } = this.source
+    const summary = await getLivepeerDelegateAccount(delegateAddress)
     const { address } = summary
     return {
       summary: {
@@ -180,8 +180,8 @@ class DelegateService {
   }
 
   getDelegates = async () => {
-    const { getLivepeerTranscoders } = this.source
-    const delegates = await getLivepeerTranscoders()
+    const { getLivepeerDelegates } = this.source
+    const delegates = await getLivepeerDelegates()
     return delegates
   }
 }

--- a/server/helpers/utils.js
+++ b/server/helpers/utils.js
@@ -236,12 +236,12 @@ const getSubscriptorRole = async subscriptor => {
 
 const getDidDelegateCalledReward = async delegateAddress => {
   const { getProtocolService } = require('./services/protocolService')
-  const { getLivepeerTranscoderAccount } = require('./sdk') // should use delegateService but the value lastRewardRound is not updated
+  const { getLivepeerDelegateAccount } = require('./sdk') // should use delegateService but the value lastRewardRound is not updated
   const protocolService = getProtocolService()
 
   const [delegate, currentRoundInfo] = await promiseRetry(retry => {
     return Promise.all([
-      getLivepeerTranscoderAccount(delegateAddress),
+      getLivepeerDelegateAccount(delegateAddress),
       protocolService.getCurrentRoundInfo()
     ]).catch(err => retry())
   })

--- a/test/delegate.test.js
+++ b/test/delegate.test.js
@@ -29,7 +29,9 @@ describe('## DelegateService test', () => {
       // given
       const delegate = createTranscoder()
       // stubs the delegateGraphql service
-      const getSummaryStub = sinon.stub(delegatesGraphql, 'getDelegateSummary').returns(delegate)
+      const getSummaryStub = sinon
+        .stub(delegatesGraphql, 'getLivepeerTranscoderAccount')
+        .returns(delegate)
       const resultExpected = {
         ...delegate,
         totalStake: tokenAmountInUnits(delegate.totalStake)
@@ -49,7 +51,9 @@ describe('## DelegateService test', () => {
     // given
     const delegate = createTranscoder()
     // stubs the delegateGraphql service
-    const getSummaryStub = sinon.stub(delegatesGraphql, 'getDelegateSummary').returns(delegate)
+    const getSummaryStub = sinon
+      .stub(delegatesGraphql, 'getLivepeerTranscoderAccount')
+      .returns(delegate)
     const resultExpected = {
       summary: {
         ...delegate,

--- a/test/delegate.test.js
+++ b/test/delegate.test.js
@@ -30,7 +30,7 @@ describe('## DelegateService test', () => {
       const delegate = createTranscoder()
       // stubs the delegateGraphql service
       const getSummaryStub = sinon
-        .stub(delegatesGraphql, 'getLivepeerTranscoderAccount')
+        .stub(delegatesGraphql, 'getLivepeerDelegateAccount')
         .returns(delegate)
       const resultExpected = {
         ...delegate,
@@ -52,7 +52,7 @@ describe('## DelegateService test', () => {
     const delegate = createTranscoder()
     // stubs the delegateGraphql service
     const getSummaryStub = sinon
-      .stub(delegatesGraphql, 'getLivepeerTranscoderAccount')
+      .stub(delegatesGraphql, 'getLivepeerDelegateAccount')
       .returns(delegate)
     const resultExpected = {
       summary: {


### PR DESCRIPTION
No issue related
Fixs the getDelegateSummary of delegateService in order to be able to use both sdk or graphql
