### PR TITLE
[Task] Improve Changelog description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,33 +4,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.2.1] - 2019-07-11
+## [1.2.1](https://github.com/protofire/livepeer-alerts-backend/compare/v1.2.0...v1.2.1) (2019-07-11)
 ### Fixes
-- Unsubscribe link in notifications
+- Broken unsubscribe link in notifications [#76](https://github.com/protofire/livepeer-alerts-backend/pull/76)
 
-## [1.2.0] - 2019-07-08
+## [1.2.0](https://github.com/protofire/livepeer-alerts-backend/compare/v1.2.0...v1.1.2) (2019-07-08)
 ### Add
-- Send a notification when my bonded-delegate changes his rules
+- Send a notification when my bonded-delegate changes his rules [#68](https://github.com/protofire/livepeer-alerts-backend/pull/68), Closes [#55](https://github.com/protofire/livepeer-alerts-backend/issues/55) [#49](https://github.com/protofire/livepeer-alerts-backend/issues/49)
 
-## [1.1.2] - 2019-07-04
 ### Fixes
-- App is sending an email every hour, added verification flag, updated sdk livepeer package
+- Refactors both sendTelegramClaimRewardCall() and getBodyBySubscriber() functions in order to use the getDidDelegateCallReward() utility function [#63](https://github.com/protofire/livepeer-alerts-backend/pull/63)
+- The values of the ROI in top delegates where all the same, the problem was the usage of getDelegate() function. it was expected to return directly the reward cut, but was a summary object instead [#67](https://github.com/protofire/livepeer-alerts-backend/pull/67)
 
-## [1.1.1] - 2019-07-04
+## [1.1.2](https://github.com/protofire/livepeer-alerts-backend/compare/v1.1.2...v1.1.1) (2019-07-04)
 ### Fixes
--  The summary functions returns an invalid delegateCalledReward value
+- App is sending an email every hour, added verification flag, updated SDK livepeer package [#66](https://github.com/protofire/livepeer-alerts-backend/pull/66), Closes [#64](https://github.com/protofire/livepeer-alerts-backend/issues/64)
 
-## [1.1.0] - 2019-06-28
+## [1.1.1](https://github.com/protofire/livepeer-alerts-backend/compare/v1.1.1...v1.1.0) (2019-07-04)
+### Fixes
+-  The summary functions returns an invalid delegateCalledReward value [#62](https://github.com/protofire/livepeer-alerts-backend/pull/62), Closes [#65](https://github.com/protofire/livepeer-alerts-backend/issues/65)
+
+## [1.1.0](eer-alerts-backend/compare/v1.1.0...v1.0.0) (2019-06-28)
 ### Add
-- More tests
-- Graphql queries
-- Services based on SDK or Graphql
-- Apollo client
-- Improvements in workers
+- More tests [#41](https://github.com/protofire/livepeer-alerts-backend/pull/41)
+- Graphql queries [#37](https://github.com/protofire/livepeer-alerts-backend/pull/37)
+- Services based on SDK or Graphql [#42](https://github.com/protofire/livepeer-alerts-backend/pull/42)
+- Apollo client [#37](https://github.com/protofire/livepeer-alerts-backend/pull/37)
+- Improvements in workers [#53](https://github.com/protofire/livepeer-alerts-backend/pull/53)
 
 ### Fixes
-- Earnings notification
+- Earnings notification [#40](https://github.com/protofire/livepeer-alerts-backend/pull/40) [#43](https://github.com/protofire/livepeer-alerts-backend/pull/43) [#50](https://github.com/protofire/livepeer-alerts-backend/pull/50)
+- Fix security issues [#36](https://github.com/protofire/livepeer-alerts-backend/pull/36)
 
-## [1.0.0] - 2018-12-17
+## [1.0.0](https://github.com/protofire/livepeer-alerts-backend/compare/666886a084841f6587653e419bb174d0bb87e208...v1.0.0) (2018-12-17)
 ### Added
 - Initial commit


### PR DESCRIPTION
Closes #79 

Added:
- Compare tags
- Links to PR and somes issues

I think that adding the links of the commits is a very big task and that it will make the changelog lose its meaning, when it should show a simple description of the progress of the versions of the application