### PR TITLE
(Feature) Delegator endpoint

### DIFF
--- a/server/delegator/delegator.controller.js
+++ b/server/delegator/delegator.controller.js
@@ -17,6 +17,18 @@ const getNextReward = async (req, res, next) => {
   }
 }
 
+const getDelegator = async (req, res, next) => {
+  const { address } = req.params
+  try {
+    const delegatorService = getDelegatorService()
+    const delegator = await delegatorService.getDelegatorAccount(address)
+    res.json({ delegator })
+  } catch (error) {
+    next(error)
+  }
+}
+
 module.exports = {
-  getNextReward
+  getNextReward,
+  getDelegator
 }

--- a/server/delegator/delegator.route.js
+++ b/server/delegator/delegator.route.js
@@ -3,12 +3,17 @@ const validate = require('express-validation')
 const paramValidation = require('../../config/param-validation')
 
 const router = express.Router() // eslint-disable-line new-cap
-const { getNextReward } = require('./delegator.controller')
+const { getNextReward, getDelegator } = require('./delegator.controller')
 
 /** GET /api/delegators/reward/:address - Get delegate next reward by address */
 router
   .route('/reward/:address')
 
   .get(validate(paramValidation.getByAddress), getNextReward)
+
+router
+  .route('/address/:address')
+
+  .get(validate(paramValidation.getByAddress), getDelegator)
 
 module.exports = router

--- a/utils/livepeer-alerts-backend.postman_collection.json
+++ b/utils/livepeer-alerts-backend.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "57a8f6cc-574a-4168-9238-50fc0ba10bb6",
+		"_postman_id": "fd460187-e73f-4bb0-a0d5-3a0500c0e2fd",
 		"name": "livepeer-alerts-backend",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -500,6 +500,39 @@
 						"0xda43d85b8d419a9c51bbf0089c9bd5169c23f2f9"
 					]
 				}
+			},
+			"response": []
+		},
+		{
+			"name": "[GET] - /api/delegators/address/:address",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Referer",
+						"value": "http://localhost:3000",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "http://localhost:4040/api/delegators/address/0x155cCf41305F5fE3FAae64eCea8a1E2cAd08F085",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "4040",
+					"path": [
+						"api",
+						"delegators",
+						"address",
+						"0x155cCf41305F5fE3FAae64eCea8a1E2cAd08F085"
+					]
+				},
+				"description": "Gets information about a delegator"
 			},
 			"response": []
 		}


### PR DESCRIPTION
No issue related
Adds the posibility to fetch information of a delegator with an API
Updates postman doc

Example:
```
http://localhost:4040/api/delegators/address/thisIsAnAddress
```

Returns:
```
{
    "delegator": {
        "address": "thisIsAnAddress",
        "allowance": "83129443200000000000",
        "bondedAmount": "1456786800000000000",
        "delegateAddress": "delegateAddress",
        "delegatedAmount": "0",
        "fees": "0",
        "lastClaimRound": "1403",
        "pendingFees": "0",
        "pendingStake": "138756800000000000",
        "startRound": "1404",
        "status": "Bonded",
        "withdrawRound": "0",
        "withdrawAmount": "0",
        "nextUnbondingLockId": "0",
        "totalStake": "1214656800000000000"
    }
}
```