### PR TITLE
(Feature) Duplicated pools

### DIFF
--- a/server/helpers/subscriberUtils.js
+++ b/server/helpers/subscriberUtils.js
@@ -162,7 +162,7 @@ const getSubscriptorRole = async subscriptor => {
   try {
     const constants = await protocolService.getLivepeerDefaultConstants()
     console.log(
-      `[Subscribers-utils] - getDelegatorAccount() for subscriptor: ${subscriptor.address}`
+      `[Subscribers-utils] - getDelegatorAccount() for subscriptor: ${subscriptor._id} with delegateAddress: ${subscriptor.address}`
     )
     const delegator = await delegatorService.getDelegatorAccount(subscriptor.address)
     console.log(`[Subscribers-utils] - getDelegatorAccount() finished, detecting role`)

--- a/server/helpers/updateRoundPools.js
+++ b/server/helpers/updateRoundPools.js
@@ -40,8 +40,9 @@ const updateDelegatePoolsOfRound = async (round, roundPools) => {
     const foundPool = await Pool.findById(poolId)
     if (foundPool) {
       console.error(
-        `[Update Delegates Pools] - The pool  ${poolId} already exist on the db, skipping updateDelegatePoolsOfRound`
+        `[Update Delegates Pools] - The pool  ${poolId} already exist on the db, skipping the update of it on the db`
       )
+      continue
     }
     // Fetch the delegate current totalStake and the local delegate related to the pool
     let [totalStakeOnRound, delegate] = await Promise.all([

--- a/server/helpers/updateRoundPools.js
+++ b/server/helpers/updateRoundPools.js
@@ -28,12 +28,20 @@ const updateDelegatePoolsOfRound = async (round, roundPools) => {
 
   // Persists the pools locally
   for (let poolIterator of roundPools) {
+    const poolId = poolIterator.id
     const delegateId = poolIterator.transcoder.id
     if (!delegateId) {
       console.error(
-        `[Update Delegates Pools] - The pool ${poolIterator.id} does not contain a valid delegate`
+        `[Update Delegates Pools] - The pool ${poolId} does not contain a valid delegate`
       )
       continue
+    }
+    // Checks that the pool does not already exists
+    const foundPool = await Pool.findById(poolId)
+    if (foundPool) {
+      console.error(
+        `[Update Delegates Pools] - The pool  ${poolId} already exist on the db, skipping updateDelegatePoolsOfRound`
+      )
     }
     // Fetch the delegate current totalStake and the local delegate related to the pool
     let [totalStakeOnRound, delegate] = await Promise.all([
@@ -43,7 +51,7 @@ const updateDelegatePoolsOfRound = async (round, roundPools) => {
     if (!delegate) {
       // This should not happen because all the delegates on the db should be updated first
       console.error(
-        `[Update Delegates Pools] - The delegate ${delegateId} of the pool ${poolIterator.id} was not found, did you call the updateDelegatesJob() before?`
+        `[Update Delegates Pools] - The delegate ${delegateId} of the pool ${poolId} was not found, did you call the updateDelegatesJob() before?`
       )
       continue
     }
@@ -52,7 +60,7 @@ const updateDelegatePoolsOfRound = async (round, roundPools) => {
       const { roundId } = round
       // Creates the pool object
       let newSavedPool = new Pool({
-        _id: poolIterator.id,
+        _id: poolId,
         rewardTokens: poolIterator.rewardTokens,
         totalStakeOnRound,
         delegate: delegateId,

--- a/server/helpers/updateRoundShares.js
+++ b/server/helpers/updateRoundShares.js
@@ -55,7 +55,16 @@ const updateDelegatorSharesOfRound = async (round, delegator) => {
     delegate: delegatorAddress,
     round: roundId
   })
-
+  // Checks that the share does not already exists
+  const foundShare = await Share.findById(shareId)
+  if (foundShare) {
+    console.error(
+      `[Update Delegators Shares] - Error Updating share: ${shareId} on delegator ${delegatorAddress}, the share already exists, skipping save`
+    )
+    throw new Error(
+      `[Update Delegators Shares] - Error Updating share: ${shareId} on delegator ${delegatorAddress}, the share already exists, skipping save`
+    )
+  }
   try {
     // Saves the share
     console.log(`[Update Delegators Shares] - Saving new share for delegator ${delegatorAddress}`)


### PR DESCRIPTION
Closes #111 

## Description
Mongo does not support duplicate checks for subdocuments, the only way to avoid this is check that on the application layer. We weren't doing this for both pools and shares. Not before we update the list of pools or shares we check if that object it no already saved.
