### PR TITLE
(Feature) Removes the formating of the delegator shares

### DIFF
--- a/server/helpers/delegatorUtils.js
+++ b/server/helpers/delegatorUtils.js
@@ -296,10 +296,12 @@ const getDelegatorSummary30RoundsRewards = async delegatorAddress => {
   delegateLastRoundReward = utils.tokenAmountInUnits(delegateLastRoundReward)
   delegate7RoundsRewards = utils.tokenAmountInUnits(delegate7RoundsRewards)
   delegate30RoundsRewards = utils.tokenAmountInUnits(delegate30RoundsRewards)
+  // Disabled to test the shares formated values, once severals rounds passed and the results seems ok, this code should be deleted
+  /*
   delegatorLastRoundReward = utils.tokenAmountInUnits(delegatorLastRoundReward)
   delegator7RoundsRewards = utils.tokenAmountInUnits(delegator7RoundsRewards)
   delegator30RoundsRewards = utils.tokenAmountInUnits(delegator30RoundsRewards)
-
+   */
   return {
     nextReward: {
       delegatorReward: delegatorNextReward,


### PR DESCRIPTION
No issue related
The shares of the delegators have been formated in 18 decimals, but are were stored "in units" format. So no formate is required, this pr fixs that