### PR TITLE
(Feature) Show only last shares rounds

### DIFF
--- a/server/helpers/delegatorUtils.js
+++ b/server/helpers/delegatorUtils.js
@@ -263,6 +263,8 @@ const getDelegatorSummary30RoundsRewards = async delegatorAddress => {
   const lastRoundStartValue = currentRound - 1
   const last7RoundStartValue = currentRound - 7
   const last30RoundStartValue = currentRound - 30
+  let amountOfSharesFor7RoundsAvailable = 0
+  let amountOfSharesFor30RoundsAvailable = 0
 
   delegatorShares.forEach(share => {
     if (share.round === lastRoundStartValue.toString()) {
@@ -270,11 +272,28 @@ const getDelegatorSummary30RoundsRewards = async delegatorAddress => {
     }
     if (share.round >= last7RoundStartValue.toString()) {
       delegator7RoundsRewards = utils.MathBN.add(delegator7RoundsRewards, share.rewardTokens)
+      amountOfSharesFor7RoundsAvailable++
     }
     if (share.round >= last30RoundStartValue.toString()) {
       delegator30RoundsRewards = utils.MathBN.add(delegator30RoundsRewards, share.rewardTokens)
+      amountOfSharesFor30RoundsAvailable++
     }
   })
+
+  // Only calculates 7 rounds rewards if on every round of the 7 rounds there are shares, otherwise returns 0
+  if (amountOfSharesFor7RoundsAvailable !== 7) {
+    console.log(
+      `[DelegatorUtils] - not enough rounds shares for displaying 7 rounds shares, amount available: ${amountOfSharesFor7RoundsAvailable}`
+    )
+    delegator7RoundsRewards = new Big(0)
+  }
+  // Only calculates 30 rounds rewards if on every round of the 30 rounds there are shares, otherwise returns 0
+  if (amountOfSharesFor30RoundsAvailable !== 30) {
+    console.log(
+      `[DelegatorUtils] - not enough rounds shares for displaying 30 rounds shares, amount available: ${amountOfSharesFor30RoundsAvailable}`
+    )
+    delegator30RoundsRewards = new Big(0)
+  }
 
   let delegateLastRoundReward = new Big(0)
   let delegate7RoundsRewards = new Big(0)
@@ -296,12 +315,7 @@ const getDelegatorSummary30RoundsRewards = async delegatorAddress => {
   delegateLastRoundReward = utils.tokenAmountInUnits(delegateLastRoundReward)
   delegate7RoundsRewards = utils.tokenAmountInUnits(delegate7RoundsRewards)
   delegate30RoundsRewards = utils.tokenAmountInUnits(delegate30RoundsRewards)
-  // Disabled to test the shares formated values, once severals rounds passed and the results seems ok, this code should be deleted
-  /*
-  delegatorLastRoundReward = utils.tokenAmountInUnits(delegatorLastRoundReward)
-  delegator7RoundsRewards = utils.tokenAmountInUnits(delegator7RoundsRewards)
-  delegator30RoundsRewards = utils.tokenAmountInUnits(delegator30RoundsRewards)
-   */
+
   return {
     nextReward: {
       delegatorReward: delegatorNextReward,

--- a/server/helpers/updateRoundShares.js
+++ b/server/helpers/updateRoundShares.js
@@ -39,7 +39,7 @@ const updateDelegatorSharesOfRound = async (round, delegator) => {
   }
 
   // Creates the share object
-  const { totalStake } = delegator
+  const { totalStake, delegate } = delegator
   const shareId = `${delegatorAddress}-${roundId}`
   const rewardTokens = await delegatorUtils.getDelegatorCurrentRewardTokens(
     roundId,
@@ -52,7 +52,7 @@ const updateDelegatorSharesOfRound = async (round, delegator) => {
     rewardTokens,
     totalStakeOnRound: totalStake,
     delegator: delegatorAddress,
-    delegate: delegatorAddress,
+    delegate: delegate,
     round: roundId
   })
   // Checks that the share does not already exists


### PR DESCRIPTION
No issue related

## Description
- Now the endpoint `/last-rewards/:address` returns 0 on the `last7DelegatorRewards` and `last30DelegatorRewards` if there are not enough shares (7 and 30) to make the calculation, for example: if there are 8 rounds but the round 6 does not have shares, will return 0
- Also fixs a bug related to the delegator shares: the `delegateAddress` was not stored, but the `delegatorAddress` instead