### PR TITLE
(Feature) Replaces the initial share of the delegator with 0

### DIFF
--- a/server/helpers/delegatorUtils.js
+++ b/server/helpers/delegatorUtils.js
@@ -43,12 +43,9 @@ const getDelegatorCurrentRewardTokens = async (
   const lastRoundId = currentRoundId - 1
   const lastDelegatorShareId = `${delegatorAddress}-${lastRoundId}`
   const lastDelegatorShare = await Share.findById(lastDelegatorShareId)
-  // The first time we register the delegator on the db, he won't have any shares, we save as default value, the delegatorNextReward (an approximation of how much the delegator has obtained)
+  // The first time we register the delegator on the db, he won't have any shares
   if (!lastDelegatorShare) {
-    const { getDelegatorService } = require('../helpers/services/delegatorService')
-    const delegatorService = getDelegatorService()
-    console.error('[Delegator utils] - last share not found')
-    return await delegatorService.getDelegatorNextReward(delegatorAddress)
+    return null
   }
   const newShare = utils.MathBN.sub(
     currentDelegatorTotalStake,

--- a/server/helpers/updateRoundShares.js
+++ b/server/helpers/updateRoundShares.js
@@ -41,11 +41,18 @@ const updateDelegatorSharesOfRound = async (round, delegator) => {
   // Creates the share object
   const { totalStake, delegate } = delegator
   const shareId = `${delegatorAddress}-${roundId}`
-  const rewardTokens = await delegatorUtils.getDelegatorCurrentRewardTokens(
+  let rewardTokens = await delegatorUtils.getDelegatorCurrentRewardTokens(
     roundId,
     delegatorAddress,
     totalStake
   )
+  if (!rewardTokens) {
+    // If the delegate has no shares for the given round, the reward tokens should be 0
+    console.log(
+      `[Update Delegators Shares] - The delegator ${delegatorAddress} has no shares for the round ${roundId}, saving 0 instead`
+    )
+    rewardTokens = '0'
+  }
 
   let newSavedShared = new Share({
     _id: shareId,

--- a/test/share.test.js
+++ b/test/share.test.js
@@ -100,12 +100,12 @@ describe('## Share static methods test', () => {
       // then
       expect(expectedThrow).equal(throwedError)
     })
-    it('If the delegator has no shares on the last round, should return the delegatorNextReward', async () => {
+    it('If the delegator has no shares on the last round, should return null', async () => {
       // given
       const roundId = '1'
       const delegatorAddress = '1'
       const currentDelegatorTotalStake = '1000'
-      const resultExpected = 0
+      const resultExpected = null
 
       const shareMock = sinon.mock(Share)
 


### PR DESCRIPTION
No issue related

## Description
- We were saving the initial share amount of the delegator equal to the `delegatorNextReward`, this value is invalid, the first reason is because it's formated (and we are storing all the shares in a non-formated way). The second reason it's because it's a "wrong-reward", it's not real but an aproximation of the next round reward, if the delegate did not claim the reward, then it won't even happen